### PR TITLE
add init.d script for starting demos on boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ $ make all
 $ ./random-dots
 ```
 
+To run the demos on boot, see the `init.d` directory.
+
 ### Demos provided
 
 Use the `-?` command-line option on any demo program to list it's options.

--- a/init.d/flaschen-taschen-demos
+++ b/init.d/flaschen-taschen-demos
@@ -1,0 +1,92 @@
+#!/bin/sh
+
+### BEGIN INIT INFO
+# Provides:		run-nb3.sh
+# Required-Start:	udev $remote_fs $all
+# Required-Stop:	$remote_fs
+# Should-Start:
+# Should-Stop:
+# Default-Start:	4 5
+# Default-Stop:		0 6
+# Short-Description:	Start ft-demos/scripts/run-nb3.sh after boot and kill it on shutdown
+### END INIT INFO
+
+FT_HOME="/home/noisebridge/code/ft-demos"
+FT_SCRIPTS="${FT_HOME}/scripts"
+FT_DEMOS="${FT_SCRIPTS}/run-nb3.sh"
+PATH="/sbin:/bin:/usr/sbin:/usr/bin:${FT_SCRIPTS}"
+NAME="run-nb3.sh"
+DESC="Flaschen-taschen demos"
+
+DAEMON="${FT_DEMOS}"
+DAEMON_OPTS=""
+RUN_AS_USER="noisebridge"
+COMMAND="${1}"
+
+# Erase the incoming params ($1 etc), so that sourced systemd/init.d functions don't act on them
+# We want this script to be invoked by systemd, but to not affect anything outside of it
+set -- "" "" ""
+
+# Get lsb functions
+. /lib/lsb/init-functions
+
+test -x "${DAEMON}" || exit 0
+
+if [ -r "/etc/default/${NAME}" ]
+then
+	. "/etc/default/${NAME}"
+fi
+
+case "$COMMAND" in
+  start)
+        log_daemon_msg "Startingg $DESC" "$NAME"
+        start-stop-daemon --start --quiet --user $RUN_AS_USER --pidfile /var/run/$NAME.pid \
+                --exec $DAEMON -- $DAEMON_OPTS
+        log_end_msg $?
+        ;;
+  stop)
+        log_daemon_msg "Stopping $DESC" "$NAME"
+        start-stop-daemon --stop --oknodo --quiet --user $RUN_AS_USER --pidfile /var/run/$NAME.pid \
+                --retry 10 --exec $DAEMON
+        log_end_msg $?
+        ;;
+  force-reload)
+        # check whether $DAEMON is running. If so, restart
+        start-stop-daemon --stop --test --quiet --user $RUN_AS_USER --pidfile \
+                /var/run/$NAME.pid --exec $DAEMON \
+        && $0 restart \
+        || exit 0
+        ;;
+  restart)
+        log_daemon_msg "Restarting $DESC" "$NAME"
+        $0 stop
+        $0 start
+        ;;
+  status)
+        if [ -s /var/run/$NAME.pid ]; then
+            RUNNING=$(cat /var/run/$NAME.pid)
+            if [ -d /proc/$RUNNING ]; then
+                if [ $(readlink /proc/$RUNNING/exe) = $DAEMON ]; then
+                    log_success_msg "$NAME is running"
+                    exit 0
+                fi
+            fi
+
+            # No such PID, or executables don't match
+            log_failure_msg "$NAME is not running, but pidfile existed"
+            rm /var/run/$NAME.pid
+            exit 1
+        else
+            rm -f /var/run/$NAME.pid
+            log_failure_msg "$NAME not running"
+            exit 1
+        fi
+        ;;
+  *)
+        N=/etc/init.d/$NAME
+        log_failure_msg "Usage: $N {start|stop|restart|force-reload}"
+        exit 1
+        ;;
+esac
+
+exit 0

--- a/init.d/starting-on-boot-initd.md
+++ b/init.d/starting-on-boot-initd.md
@@ -1,0 +1,23 @@
+## What is this?
+
+After installing ft-demos on your machine, you can start it on boot by creating an init.d script.
+
+An example for that script lives under `init.d/flaschen-taschen-demos`.
+
+## Installation
+1. Copy the script: `cp init.d/flaschen-taschen-demos /etc/init.d/`
+2. Make it executable: `chmod +x /etc/init.d/flaschen-taschen-demos`
+3. Add it to the boot sequence: `update-rc.d flaschen-taschen-demos defaults`
+
+## Usage - like any other service
+1. Start the service: `service flaschen-taschen-demos start`
+2. Stop the service: `service flaschen-taschen-demos stop`
+3. Restart the service: `service flaschen-taschen-demos restart`
+
+## What about the flaschen-taschen server?
+
+The flaschen-taschen server lives under its own repo, https://github.com/hzeller/flaschen-taschen
+
+There you will find instructions for running the server, including an init.d script for starting the server on boot.
+
+The two init.d scripts will result in flaschen-taschen starting up and displaying as expected.


### PR DESCRIPTION
## Summary
On the discord f-t channel there was interest in making the rpi start ft-demos on boot. This does that.

There will be a [similar pull](https://github.com/hzeller/flaschen-taschen/pull/73) for hzeller's ft-server

## Adds|updates the following files-
- init.d/flaschen-taschen-demos: script for starting demos on boot
- init.d/starting-on-boot-initd.md
- README.md: add line mentioning the init.d script

## Tests
Manually tested on the Noisebridge flaschen-taschen raspberrypi.  Works!

